### PR TITLE
Introduce Result type for QualificationAppInfo

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/OperationResult.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/OperationResult.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021-2023, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.tool.util
+
+sealed trait OperationResult[+T]
+case class SuccessResult[T](result: T) extends OperationResult[T]
+case class FailureResult(errorMessage: String) extends OperationResult[Nothing]

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/SqlPlanParserSuite.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions.{ceil, col, collect_list, count, explode, floor, hex, json_tuple, round, row_number, sum}
 import org.apache.spark.sql.rapids.tool.ToolUtils
 import org.apache.spark.sql.rapids.tool.qualification.QualificationAppInfo
-import org.apache.spark.sql.rapids.tool.util.RapidsToolsConfUtil
+import org.apache.spark.sql.rapids.tool.util.{FailureResult, OperationResult, RapidsToolsConfUtil, SuccessResult}
 import org.apache.spark.sql.types.StringType
 
 
@@ -75,10 +75,12 @@ class SQLPlanParserSuite extends BaseTestSuite {
       None, None, List(eventLog), hadoopConf)
     val pluginTypeChecker = new PluginTypeChecker()
     assert(allEventLogs.size == 1)
-    val appOption = QualificationAppInfo.createApp(allEventLogs.head, hadoopConf,
+    val appResult = QualificationAppInfo.createApp(allEventLogs.head, hadoopConf,
       pluginTypeChecker, reportSqlLevel = false, mlOpsEnabled = false)
-    assert(appOption.nonEmpty)
-    appOption.get
+    appResult match {
+      case SuccessResult(app) => app
+      case _: FailureResult => throw new AssertionError("Cannot create application")
+    }
   }
 
   private def getAllExecsFromPlan(plans: Seq[PlanInfo]): Seq[ExecInfo] = {


### PR DESCRIPTION
This PR introduces `OperationResult` class and wraps the output of `createApp()` in  `QualificationAppInfo` in either `SuccessResult` or `FailureResult` type.

Signed-off-by: [Partho Sarthi](mailto:psarthi@nvidia.com)