### PR TITLE
Update tests in qualification tools to verify status reports

### DIFF
--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/qualification/QualificationAppInfo.scala
@@ -30,7 +30,6 @@ import org.apache.spark.scheduler.{SparkListener, SparkListenerEvent}
 import org.apache.spark.sql.execution.SparkPlanInfo
 import org.apache.spark.sql.execution.ui.SparkPlanGraph
 import org.apache.spark.sql.rapids.tool.{AppBase, GpuEventLogException, SupportedMLFuncsName, ToolUtils}
-import org.apache.spark.sql.rapids.tool.util._
 
 class QualificationAppInfo(
     eventLogInfo: Option[EventLogInfo],

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationSuite.scala
@@ -23,7 +23,7 @@ import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import scala.io.Source
 
 import com.nvidia.spark.rapids.BaseTestSuite
-import com.nvidia.spark.rapids.tool.{EventLogPathProcessor, ToolTestUtils}
+import com.nvidia.spark.rapids.tool.{EventLogPathProcessor, StatusReportCounts, ToolTestUtils}
 import org.apache.hadoop.fs.{FileSystem, Path}
 
 import org.apache.spark.ml.feature.PCA
@@ -146,7 +146,8 @@ class QualificationSuite extends BaseTestSuite {
   }
 
   private def runQualificationTest(eventLogs: Array[String], expectFileName: String,
-      shouldReturnEmpty: Boolean = false, expectPerSqlFileName: Option[String] = None) = {
+      shouldReturnEmpty: Boolean = false, expectPerSqlFileName: Option[String] = None,
+      expectedStatus: Option[StatusReportCounts] = None) = {
     TrampolineUtil.withTempDir { outpath =>
       val resultExpectation = new File(expRoot, expectFileName)
       val outputArgs = Array(
@@ -166,6 +167,14 @@ class QualificationSuite extends BaseTestSuite {
       import spark2.implicits._
       val summaryDF = createSummaryForDF(appSum).toDF
       val dfQual = sparkSession.createDataFrame(summaryDF.rdd, schema)
+
+      // Default expectation for the status counts - All applications are successful.
+      val expectedStatusCounts =
+        expectedStatus.getOrElse(StatusReportCounts(appSum.length, 0, 0))
+      // Compare the expected status counts with the actual status counts from the application
+      ToolTestUtils.compareStatusReport(sparkSession, outpath.getAbsolutePath,
+        expectedStatusCounts)
+
       if (shouldReturnEmpty) {
         assert(appSum.head.estimatedInfo.sqlDfDuration == 0.0)
       } else {
@@ -264,6 +273,11 @@ class QualificationSuite extends BaseTestSuite {
       assert(exit == 0)
       assert(appSum.size == 4)
       assert(appSum.head.appId.equals("local-1622043423018"))
+
+      // Default expectation for the status counts - All applications are successful.
+      val expectedStatusCount = StatusReportCounts(appSum.length, 0, 0)
+      // Compare the expected status counts with the actual status counts from the application
+      ToolTestUtils.compareStatusReport(sparkSession, outpath.getAbsolutePath, expectedStatusCount)
 
       val filename = s"$outpath/rapids_4_spark_qualification_output/" +
         s"rapids_4_spark_qualification_output.log"
@@ -435,7 +449,8 @@ class QualificationSuite extends BaseTestSuite {
     val profileLogDir = ToolTestUtils.getTestResourcePath("spark-events-profiling")
     val badEventLog = s"$profileLogDir/malformed_json_eventlog.zstd"
     val logFiles = Array(s"$logDir/nds_q86_test", badEventLog)
-    runQualificationTest(logFiles, "nds_q86_test_expectation.csv")
+    val expectedStatus = Some(StatusReportCounts(1, 1, 0))
+    runQualificationTest(logFiles, "nds_q86_test_expectation.csv", expectedStatus = expectedStatus)
   }
 
   test("spark2 eventlog") {


### PR DESCRIPTION
This PR updates the existing unit tests in qualification tools to verify status report. 

Changes:
1. Add new case class `StatusReportCount` to store the count of success, failure, unknown for each test.
2. Add a new method `compareStatusReport()` in `ToolTestUtils` to compare actual and expected statuses.
3. Handle the corner case when all applications are failure and the status report file is not generated.