### PR TITLE
Replace `FailureQualAppResult` with `UnknownQualAppResult` for consistency with ProgressBar

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/qualification/Qualification.scala
@@ -171,7 +171,7 @@ class Qualification(outputDir: String, numRows: Int, hadoopConf: Configuration,
         case Left(errorMessage: String) =>
           // Case when an error occurred during QualificationAppInfo creation
           progressBar.foreach(_.reportUnkownStatusProcess())
-          FailureQualAppResult(pathStr, errorMessage)
+          UnknownQualAppResult(pathStr, "", errorMessage)
         case Right(app: QualificationAppInfo) =>
           // Case with successful creation of QualificationAppInfo
           val qualSumInfo = app.aggregateStats()


### PR DESCRIPTION
This PR replace `FailureQualAppResult` with `UnknownQualAppResult` for consistency with Progress Bar.