### PR TITLE
Fix cluster recommendation when CPU cluster cannot be determined

### DIFF
--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py
@@ -248,9 +248,12 @@ class DatabricksCluster(ClusterBase):
         # construct worker nodes info when cluster is inactive
         executors_cnt = len(worker_nodes_from_conf) if worker_nodes_from_conf else 0
         if num_workers != executors_cnt:
-            self.logger.warning('Cluster configuration: `executors` count %d does not match the '
-                                '`num_workers` value %d. Using generated names.', executors_cnt,
-                                num_workers)
+            if not self.is_inferred:
+                # this warning should be raised only when the cluster is not inferred, i.e. user has provided the
+                # cluster configuration with num_workers explicitly set
+                self.logger.warning('Cluster configuration: `executors` count %d does not match the '
+                                    '`num_workers` value %d. Using the `num_workers` value.', executors_cnt,
+                                    num_workers)
             worker_nodes_from_conf = self.generate_node_configurations(num_workers)
         if num_workers == 0 and self.props.get_value('node_type_id') is None:
             # if there are no worker nodes and no node_type_id, then we cannot proceed

--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
@@ -307,9 +307,12 @@ class DatabricksAzureCluster(ClusterBase):
         # construct worker nodes info when cluster is inactive
         executors_cnt = len(worker_nodes_from_conf) if worker_nodes_from_conf else 0
         if num_workers != executors_cnt:
-            self.logger.warning('Cluster configuration: `executors` count %d does not match the '
-                                '`num_workers` value %d. Using generated names.', executors_cnt,
-                                num_workers)
+            if not self.is_inferred:
+                # this warning should be raised only when the cluster is not inferred, i.e. user has provided the
+                # cluster configuration with num_workers explicitly set
+                self.logger.warning('Cluster configuration: `executors` count %d does not match the '
+                                    '`num_workers` value %d. Using generated names.', executors_cnt,
+                                    num_workers)
             worker_nodes_from_conf = self.generate_node_configurations(num_workers)
         if num_workers == 0 and self.props.get_value('node_type_id') is None:
             # if there are no worker nodes and no node_type_id, then we cannot proceed

--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -505,9 +505,12 @@ class DataprocCluster(ClusterBase):
             worker_nodes_from_conf = self.props.get_value_silent('config', 'workerConfig', 'instanceNames')
             instance_names_cnt = len(worker_nodes_from_conf) if worker_nodes_from_conf else 0
             if worker_cnt != instance_names_cnt:
-                self.logger.warning('Cluster configuration: `instanceNames` count %d does not '
-                                    'match the `numInstances` value %d. Using generated names.',
-                                    instance_names_cnt, worker_cnt)
+                if not self.is_inferred:
+                    # this warning should be raised only when the cluster is not inferred, i.e. user has provided the
+                    # cluster configuration with num_workers explicitly set
+                    self.logger.warning('Cluster configuration: `instanceNames` count %d does not '
+                                        'match the `numInstances` value %d. Using generated names.',
+                                        instance_names_cnt, worker_cnt)
                 worker_nodes_from_conf = self.generate_node_configurations(worker_cnt)
             # create workers array
             for worker_node in worker_nodes_from_conf:

--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -1259,6 +1259,15 @@ class ClusterBase(ClusterGetAccessor):
         node_config = self._generate_node_configuration(render_args)
         return [node_config for _ in range(num_executors)]
 
+    def get_cluster_shape_str(self) -> str:
+        """
+        Returns a string representation of the cluster shape.
+        """
+        master_node = self.get_master_node().instance_type
+        executor_node = self.get_worker_node(0).instance_type
+        num_executors = self.get_nodes_cnt(SparkNodeType.WORKER)
+        return f'<Driver: {master_node}, Executor: {num_executors} X {executor_node}>'
+
 
 @dataclass
 class ClusterReshape(ClusterGetAccessor):

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -787,9 +787,8 @@ class Qualification(RapidsJarTool):
         if self.ctxt.get_ctxt('cpuClusterProxy') is not None or not self.ctxt.platform.cluster_inference_supported:
             self.logger.info('CPU cluster is already set. Skipping cluster inference.')
             return
-        cpu_cluster_cols = ['Num Executor Nodes', 'Executor Instance', 'Cores Per Executor']
-        gpu_cluster_cols = ['Recommended Num Executor Nodes', 'Recommended Executor Instance',
-                            'Recommended Cores Per Executor']
+        cpu_cluster_cols = self.ctxt.get_value('local', 'output', 'clusterInference', 'cpuClusterColumns')
+        gpu_cluster_cols = self.ctxt.get_value('local', 'output', 'clusterInference', 'gpuClusterColumns')
         # ==  Infer CPU clusters per app ==
         # Drop GPU/Recommended columns to infer the CPU cluster information
         cpu_cluster_df = cluster_info_df.drop(columns=gpu_cluster_cols, errors='ignore')

--- a/user_tools/src/spark_rapids_pytools/rapids/qualification.py
+++ b/user_tools/src/spark_rapids_pytools/rapids/qualification.py
@@ -17,14 +17,14 @@ import json
 import re
 from dataclasses import dataclass, field
 from math import ceil
-from typing import Any, List, Callable, Optional
+from typing import Any, List, Callable, Optional, Dict
 
 import numpy as np
 import pandas as pd
 from tabulate import tabulate
 
-from spark_rapids_pytools.cloud_api.sp_types import ClusterReshape, NodeHWInfo, SparkNodeType
-from spark_rapids_pytools.common.cluster_inference import ClusterInference
+from spark_rapids_pytools.cloud_api.sp_types import ClusterReshape, NodeHWInfo, ClusterBase
+from spark_rapids_pytools.common.cluster_inference import ClusterInference, ClusterType
 from spark_rapids_pytools.common.prop_manager import JSONPropertiesContainer, convert_dict_to_camel_case
 from spark_rapids_pytools.common.sys_storage import FSUtil
 from spark_rapids_pytools.common.utilities import Utils, TemplateGenerator
@@ -137,7 +137,7 @@ class QualificationSummary:
             report_content.append(f'{app_name} tool found no records to show.')
 
         if self.filter_apps_count > 0:
-            self.comments.append('\'Estimated GPU Speedup Category\' assumes the user is using the node type '
+            self.comments.append('**Estimated GPU Speedup Category assumes the user is using the node type '
                                  'recommended and config recommendations with the same size cluster as was used '
                                  'with the CPU side.')
 
@@ -713,8 +713,7 @@ class Qualification(RapidsJarTool):
             # info columns, even if `cluster_info_df` is empty.
             df = pd.merge(df, cluster_info_df, on=['App Name', 'App ID'], how='left')
             if len(cluster_info_df) > 0:
-                self.__infer_cluster_and_update_savings(cluster_info_df)
-                self.__infer_cluster_for_auto_tuning(cluster_info_df)
+                self._infer_clusters_for_apps(cluster_info_df)
         except Exception as e:  # pylint: disable=broad-except
             self.logger.error('Unable to process cluster information. Cost savings will be disabled. '
                               'Reason - %s:%s', type(e).__name__, e)
@@ -764,68 +763,47 @@ class Qualification(RapidsJarTool):
         rapids_threads_args = self._get_rapids_threads_count(self.name)
         return ['--per-sql'] + rapids_threads_args + self._create_autotuner_rapids_args()
 
-    def __infer_cluster_and_update_savings(self, cluster_info_df: pd.DataFrame):
+    def _infer_cluster_per_app(self, cluster_info_df: pd.DataFrame,
+                               cluster_type: ClusterType) -> Dict[str, Optional[ClusterBase]]:
         """
-        Update savings if CPU cluster can be inferred and corresponding GPU cluster can be defined.
-        :param cluster_info_df: Parsed cluster information.
+        Infers clusters for each app in the DataFrame and returns a dictionary of Cluster objects.
+
+        :param cluster_info_df: DataFrame containing cluster information for each app.
+        :param cluster_type: The type of cluster to infer.
+        :return: A dictionary where the key is the app ID and the value is the inferred Cluster object.
         """
-        # we actually want to use the inferred version over what user passed if possible
-        if self.ctxt.get_ctxt('cpuClusterProxy') is not None or not self.ctxt.platform.cluster_inference_supported:
-            self.logger.info('Inferred Cluster but cpu node was already set')
-            return
+        cluster_inference_obj = ClusterInference(platform=self.ctxt.platform, cluster_type=cluster_type)
+        return {
+            row['App ID']: cluster_inference_obj.infer_cluster(cluster_info_df.iloc[[index]])
+            for index, row in cluster_info_df.iterrows()
+        }
 
-        # Infer the CPU cluster from the cluster information
-        cpu_cluster_obj = ClusterInference(platform=self.ctxt.platform).infer_cpu_cluster(cluster_info_df)
-        if cpu_cluster_obj is None:
-            return
-
-        # Log the inferred cluster information and set the context
-        self._log_inferred_cluster_info(cpu_cluster_obj)
-        self.ctxt.set_ctxt('cpuClusterProxy', cpu_cluster_obj)
-
-        # Process gpu cluster arguments and update savings calculations flag
-        offline_cluster_opts = self.wrapper_options.get('migrationClustersProps', {})
-        enable_savings_flag = self._process_gpu_cluster_args(offline_cluster_opts)
-        self._set_savings_calculations_flag(enable_savings_flag)
-
-    # this function is a lot like __infer_cluster_and_update_savings but handles clusters
-    # on a per application basis and was explicitly copied to not have to deal with
-    # changing the cost savings flow at the same time. Ideally in the future they
-    # get combined back together.
-    def __infer_cluster_for_auto_tuning(self, cluster_info_df: pd.DataFrame):
+    def _infer_clusters_for_apps(self, cluster_info_df: pd.DataFrame) -> None:
+        """
+        Infer CPU and GPU clusters for each app in the DataFrame and set the inferred clusters in the context.
+        """
         # if the user passed in the cpu cluster property, use that but we still want to try to infer the gpu
         # cluster to use
         if self.ctxt.get_ctxt('cpuClusterProxy') is not None or not self.ctxt.platform.cluster_inference_supported:
-            self.logger.info('auto tuning inferred Cluster but cpu node was already set')
+            self.logger.info('CPU cluster is already set. Skipping cluster inference.')
             return
-        cpu_cluster_dict = {}
-        offline_cluster_opts = self.wrapper_options.get('migrationClustersProps', {})
-        for index, row in cluster_info_df.iterrows():
-            single_cluster_df = cluster_info_df.iloc[[index]]
-
-            # TODO - test executor instance picked up if there
-            # Infer the CPU cluster from the cluster information
-            cpu_cluster_obj = ClusterInference(platform=self.ctxt.platform).infer_cpu_cluster(single_cluster_df)
-            # Continue cluster inference for next app
-            if cpu_cluster_obj is None:
-                continue
-            cpu_cluster_dict[row['App ID']] = cpu_cluster_obj
-            # Log the inferred cluster information and set the context
-            self._log_inferred_cluster_info(cpu_cluster_obj)
-
-        self.ctxt.set_ctxt('cpuClusterInfoPerApp', cpu_cluster_dict)
-        # Process gpu cluster arguments and update savings calculations flag
-        gpu_cluster_dict = self._process_gpu_cluster_args_for_auto_tuner(offline_cluster_opts)
-        self.ctxt.set_ctxt('gpuClusterInfoPerApp', gpu_cluster_dict)
-
-    def _log_inferred_cluster_info(self, cpu_cluster_obj):
-        master_node = cpu_cluster_obj.get_master_node()
-        executor_node = cpu_cluster_obj.get_worker_node(0)
-        num_executors = cpu_cluster_obj.get_nodes_cnt(SparkNodeType.WORKER)
-        self.logger.info('Inferred Cluster => Driver: %s, Executor: %s X %s',
-                         master_node.instance_type,
-                         num_executors,
-                         executor_node.instance_type)
+        cpu_cluster_cols = ['Num Executor Nodes', 'Executor Instance', 'Cores Per Executor']
+        gpu_cluster_cols = ['Recommended Num Executor Nodes', 'Recommended Executor Instance',
+                            'Recommended Cores Per Executor']
+        # ==  Infer CPU clusters per app ==
+        # Drop GPU/Recommended columns to infer the CPU cluster information
+        cpu_cluster_df = cluster_info_df.drop(columns=gpu_cluster_cols, errors='ignore')
+        cpu_clusters_per_app = self._infer_cluster_per_app(cpu_cluster_df, ClusterType.CPU)
+        self.ctxt.set_ctxt('cpuClusterInfoPerApp', cpu_clusters_per_app)
+        # ==  Infer GPU clusters per app ==
+        # Drop CPU columns to infer the GPU cluster information
+        gpu_cluster_df = cluster_info_df.drop(columns=cpu_cluster_cols, errors='ignore')
+        # Rename GPU columns to drop the 'Recommended' prefix
+        gpu_cluster_df.rename(columns=dict(zip(gpu_cluster_cols, cpu_cluster_cols)), inplace=True)
+        # Assumption: num executors per node will be same as num gpus per node
+        gpu_cluster_df['Num Executors Per Node'] = cluster_info_df['Recommended Num GPUs Per Node']
+        gpu_clusters_per_app = self._infer_cluster_per_app(gpu_cluster_df, ClusterType.GPU)
+        self.ctxt.set_ctxt('gpuClusterInfoPerApp', gpu_clusters_per_app)
 
     def __build_output_files_info(self) -> dict:
         """

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -135,7 +135,7 @@ local:
             outputComment: "Heuristics information"
       configRecommendations:
         name: 'rapids_4_spark_qualification_output/tuning'
-        outputComment: "Cluster config recommendations"
+        outputComment: "*Cluster config recommendations"
         columns:
           - 'Full Cluster Config Recommendations*'
           - 'GPU Config Recommendation Breakdown*'

--- a/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
+++ b/user_tools/src/spark_rapids_pytools/resources/qualification-conf.yaml
@@ -341,6 +341,16 @@ local:
             dstCol: 'Estimated GPU Speedup'
           - srcCol: 'appDuration_pred'
             dstCol: 'Estimated GPU Duration'
+    clusterInference:
+      cpuClusterColumns:
+        - 'Num Executor Nodes'
+        - 'Executor Instance'
+        - 'Cores Per Executor'
+      gpuClusterColumns:
+        - 'Recommended Num Executor Nodes'
+        - 'Recommended Executor Instance'
+        - 'Recommended Cores Per Executor'
+
 platform:
   shortName: 'qual'
   outputDir: qual-tool-output


### PR DESCRIPTION
This PR fixes the issue where we do not generate a cluster recommendation when CPU cluster cannot be created (e.g., no matching executor instance found for the required number of cores). 

## Approach
Scala tool now generates a recommended GPU cluster per app basis [NVIDIA/spark-rapids-tools#1188](https://github.com/NVIDIA/spark-rapids-tools/pull/1188). For the case when CPU cluster is not provided, we should use the values from Scala tool output for our GPU cluster recommendation instead of python's cpu<->gpu core matching.

## Output

### Case 1: CPU cluster is not passed and we infer CPU cluster for each app

#### Logs (for each app):
```
INFO rapids.tools.cluster_inference: For App ID: app-20200423033538-0000, Unable to infer CPU cluster. Reason - No matching executor instance found for num cores = 80
INFO rapids.tools.cluster_recommender: For App ID: app-20200423033538-0000, CPU cluster: N/A; Recommended GPU cluster: <Driver: m6gd.xlarge, Executor: 16 X g5.4xlarge>
INFO rapids.tools.cluster_recommender: For App ID: app-20210509200722-0001, Inferred CPU cluster: <Driver: m6gd.xlarge, Executor: 1 X m6gd.4xlarge>; Recommended GPU cluster: <Driver: m6gd.xlarge, Executor: 1 X g5.4xlarge>
```


#### Final Result:
```
+----+---------------------+-------------------------+-----------------+----------------------------+------------------------------+-----------------------------+
|    | App Name            | App ID                  | Estimated GPU   | Qualified Node             | Full Cluster                 | GPU Config                  |
|    |                     |                         | Speedup         | Recommendation             | Config                       | Recommendation              |
|    |                     |                         | Category**      |                            | Recommendations*             | Breakdown*                  |
|----+---------------------+-------------------------+-----------------+----------------------------+------------------------------+-----------------------------|
|  1 | spark_test_apps.py  | app-20200423033538-0000 | Large           | g5.4xlarge                 | app-20200423033538-0000.conf | app-20200423033538-0000.log |
|  2 | Spark shell         | app-20210509200722-0001 | Small           | m6gd.4xlarge to g5.4xlarge | app-20210509200722-0001.conf | app-20210509200722-0001.log |
+----+---------------------+-------------------------+-----------------+----------------------------+------------------------------+-----------------------------+
```


### Case 2: CPU cluster is passed as input (`--cluster <cluster>`)


#### Logs (for all apps):
```
INFO rapids.tools.cluster_recommender: CPU cluster: <Driver: m6gd.xlarge, Executor: 2 X m6gd.xlarge>; Recommended GPU cluster: <Driver: m6gd.xlarge, Executor: 2 X g5.xlarge>
```

#### Final Result:
```
+----+---------------------+-------------------------+-----------------+--------------------------+------------------------------+-----------------------------+
|    | App Name            | App ID                  | Estimated GPU   | Qualified Node           | Full Cluster                 | GPU Config                  |
|    |                     |                         | Speedup         | Recommendation           | Config                       | Recommendation              |
|    |                     |                         | Category**      |                          | Recommendations*             | Breakdown*                  |
|----+---------------------+-------------------------+-----------------+--------------------------+------------------------------+-----------------------------|
|  1 | spark_test_apps.py  | app-20200423033538-0000 | Large           | m6gd.xlarge to g5.xlarge | app-20200423033538-0000.conf | app-20200423033538-0000.log |
|  2 | Spark shell         | app-20210509200722-0001 | Small           | m6gd.xlarge to g5.xlarge | app-20210509200722-0001.conf | app-20210509200722-0001.log |
+----+---------------------+-------------------------+-----------------+--------------------------+------------------------------+-----------------------------+
```