### PR TITLE
Add initial skeleton to refactor qualWrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,9 @@ target/
 # prepackage locations
 csp-resources*
 tools-resources/
+# ignore generated files pulled from other sources in the repo.
+**/resources/gen_files/
+
 
 # precommit files
 *-E

--- a/user_tools/src/spark_rapids_tools/enums.py
+++ b/user_tools/src/spark_rapids_tools/enums.py
@@ -232,3 +232,19 @@ class SubmissionMode(EnumeratedType):
     @classmethod
     def get_default(cls) -> 'SubmissionMode':
         return cls.LOCAL
+
+
+##################
+# Core Tools Enums
+##################
+
+class AppCoreStatusEnum(EnumeratedType):
+    """Values used to define the status of the applications as processed by the core-tool module"""
+    SUCCESS = 'SUCCESS'
+    FAILURE = 'FAILURE'
+    SKIPPED = 'SKIPPED'
+    UNKNOWN = 'UNKNOWN'
+
+    @classmethod
+    def get_default(cls) -> 'AppCoreStatusEnum':
+        return cls.UNKNOWN

--- a/user_tools/src/spark_rapids_tools/tools/core/app_handler.py
+++ b/user_tools/src/spark_rapids_tools/tools/core/app_handler.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation of handlers that manage a single Spark app result."""
+
+from dataclasses import dataclass
+from functools import cached_property
+
+from spark_rapids_tools.enums import AppCoreStatusEnum
+
+
+@dataclass
+class BaseAppDescriptor:
+    """
+    Holds the base information loaded from the core-tool output. This is typically
+    same information extracted from the app_status in the core tool output.
+    """
+    eventlog_path: str
+    status: AppCoreStatusEnum
+
+
+    @cached_property
+    def is_processable(self) -> bool:
+        """
+        We only process apps that were successfully analyzed by the core-tool.
+        :return: bool to indicate true if the app should be processed in the user tool
+        """
+        return self.status == AppCoreStatusEnum.SUCCESS
+
+    def __post_init__(self):
+        pass
+
+
+@dataclass
+class AppDescriptor(BaseAppDescriptor):
+    """
+    Represents a successful app results that was processed by the core-tool.
+    An instant of that class is created and it will be processed by the heuristics and QualX and
+    the report generator.
+    """
+    app_id: str
+    app_name: str
+    attempt_id: int
+
+    @cached_property
+    def uuid(self) -> str:
+        """
+        Create a unique identifier for the app. This is used to identify the app in report output
+        folders.
+        In addition, it should be used to for joining between results from different paths.
+        For now, we typically use the app_id as a unique_id.
+        However, in the future, this representation could change when we support multiple attempts.
+        In the latter case, the attempt_id should become part of the app identification.
+        :return: a unique identifier for app.
+        """
+        return f"{self.app_id}"
+
+    def __post_init__(self):
+        super().__post_init__()

--- a/user_tools/src/spark_rapids_tools/tools/core/qual_handler.py
+++ b/user_tools/src/spark_rapids_tools/tools/core/qual_handler.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation of handlers that manage and process the output of the core-tool module."""
+
+from dataclasses import dataclass, field
+from functools import cached_property
+from logging import Logger
+from typing import List
+
+import pandas as pd
+
+from spark_rapids_pytools.common.utilities import ToolLogging
+from spark_rapids_tools import CspPathT
+from spark_rapids_tools.tools.core.app_handler import AppDescriptor, BaseAppDescriptor
+
+
+@dataclass
+class QualCoreHandler(object):
+    """
+    Handler that processes the output of the core-tool module.
+
+    :param result_path: the path to the core-tool output
+    :param app_descriptors: list of apps that were analyzed by the core-tool and are ready to be
+           processed by the python wrapper.
+    :param app_raw_status: list of all eventlogs that were analyzed by the core-tool.
+           This include both failed/skipped and successfull apps
+    :param logger: logging object used for logging that section.
+    """
+    result_path: CspPathT
+    app_descriptors: List[AppDescriptor] = field(default_factory=list, init=False)
+    app_raw_status: List[BaseAppDescriptor] = field(default=list, init=False)
+    logger: Logger = field(default=None, init=False)
+    # need to define a list of apps that will be loaded from the csv files
+
+    @cached_property
+    def is_missing_core_results(self) -> bool:
+        """
+        Return true if the core-tool results are missing
+        :return: true if the core-results are missing
+        """
+        return not self.core_result_path.exists()
+
+    @cached_property
+    def core_result_path(self) -> CspPathT:
+        """
+        Return the path to the core-tool output
+        :return: the CSPAth to the core-tool output
+        """
+        return self.result_path.create_sub_path('qual_core_output')
+
+    @cached_property
+    def total_analyzed_apps(self) -> int:
+        """
+        Return the number of apps that were analyzed by the core-tool. This is typically the number
+        of eventlogs that were processed by the core-tool.
+        :return: the number of apps that were analyzed by the core-tool
+        """
+        return len(self.app_raw_status)
+
+    def has_no_processable_apps(self) -> bool:
+        """
+        API call to check if the core-tool did not produce any processable rows to be analyzed.
+        when this is true, the user-tools should understand that the apps are empty. However, it is
+        possible that the core-tool processed apps but they were all skipped (i.e., not processable)
+        :return: true, if the processable apps are no
+        """
+        return self.is_missing_core_results and not self.app_descriptors
+
+
+    def __post_init__(self):
+        self.logger = ToolLogging.get_and_setup_logger(f'rapids.tools.{self.__class__.__name__}')
+        self._load_apps()
+
+    def _load_apps(self) -> None:
+        """
+        Load the apps that were analyzed by the core-tool.
+        Steps:
+        1. load the QualOutputTable descriptor and use it to map labels to CSV files.
+        2. load the rows from app_status.csv -> this will give all the analyzed eventlogs
+        3. load the rows from app_summary.csv -> combine with appstatus to create the
+           app_descriptor object
+        :return: None
+        """
+        if self.is_missing_core_results:
+            # results are empty. there is nothing to be loaded.
+            return None
+        summary_csv = self.core_result_path.create_sub_path('apps_summary.csv')
+        status_csv = self.core_result_path.create_sub_path('status.csv')
+        # load the summary and status, then create the app lists.
+        # If an app is successful, it should be added to the app_descriptors list.
+        # Otherwise, only keep it in the app_raw_status
+        # TODO: fix the code blow
+        with status_csv.open_input_stream() as f:
+            self.app_raw_status = [BaseAppDescriptor(**row) for row in pd.read_csv(f).to_dict('records')]
+        with summary_csv.open_input_stream() as f:
+            # we should get the eventlog path and status from the BaseApp
+            self.app_descriptors = [AppDescriptor(**row) for row in pd.read_csv(f).to_dict('records')]
+        return None

--- a/user_tools/src/spark_rapids_tools/tools/core/qual_wrapper.py
+++ b/user_tools/src/spark_rapids_tools/tools/core/qual_wrapper.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation of a wrapper to process the results of the core-tool eventlog analysis."""
+
+from dataclasses import dataclass
+from typing import override
+
+from spark_rapids_pytools.rapids.qualification import QualificationAsLocal
+
+
+@dataclass
+class QualLocalV2(QualificationAsLocal):
+    """
+    Implementation of a wrapper to process the results of the core-tool eventlog analysis.
+    This class is specifically designed to handle per-app core-tool results.
+    """
+    description: str = 'This is the localQualification processes per-app core-tool results'
+
+    @override
+    def _process_output(self) -> None:
+        """
+        Process the core-tool output.
+        """
+        return None


### PR DESCRIPTION
This pull request introduces new functionality to handle and process core-tool outputs within the `spark_rapids_tools` package. Key changes include the addition of enums for application statuses, new classes for managing app descriptors, and handlers for processing core-tool results. These updates aim to enhance the modularity and functionality of the tools used for analyzing Spark application event logs.

### Core Enums Addition:
* Added `AppCoreStatusEnum` to define application statuses (`SUCCESS`, `FAILURE`, `SKIPPED`, `UNKNOWN`) for core-tool processing. (`user_tools/src/spark_rapids_tools/enums.py`, [user_tools/src/spark_rapids_tools/enums.pyR235-R250](diffhunk://#diff-30a6a6e3c62d7e94230abbda5acaa10d8526be36d1d3e1eb1bd3bf465c2a23d2R235-R250))

### App Descriptor Classes:
* Introduced `BaseAppDescriptor` and `AppDescriptor` classes to encapsulate app-related metadata, including event log paths, statuses, and unique identifiers. (`user_tools/src/spark_rapids_tools/tools/core/app_handler.py`, [user_tools/src/spark_rapids_tools/tools/core/app_handler.pyR1-R70](diffhunk://#diff-4911ad2c2b11e64105fb40654fa5d2d959af60bd927934e3aed9b5a62995e24aR1-R70))

### Core-Tool Handlers:
* Added `QualCoreHandler` to manage and process core-tool output, including loading app data from CSV files and handling missing results. (`user_tools/src/spark_rapids_tools/tools/core/qual_handler.py`, [user_tools/src/spark_rapids_tools/tools/core/qual_handler.pyR1-R110](diffhunk://#diff-7767e0bf256ff280223df7a02a74893ad917d1f984ba2f2fd62e79659f7a7a4fR1-R110))

### Wrapper for Core-Tool Results:
* Implemented `QualLocalV2` as a wrapper class to process per-app core-tool results, extending the qualification logic. (`user_tools/src/spark_rapids_tools/tools/core/qual_wrapper.py`, [user_tools/src/spark_rapids_tools/tools/core/qual_wrapper.pyR1-R36](diffhunk://#diff-2e009f68c7eefa981bfee96d353766f79a4cf7e4c43d9588e4a1d84de88bb2cdR1-R36))